### PR TITLE
Set timeout for started_event

### DIFF
--- a/capturer/__init__.py
+++ b/capturer/__init__.py
@@ -151,7 +151,7 @@ class MultiProcessHelper(object):
         self.processes.append(child_process)
         child_process.daemon = True
         child_process.start()
-        started_event.wait()
+        started_event.wait(timeout=30)
 
     def stop_children(self):
         """


### PR DESCRIPTION
If the forked process dies for some reason before started_event.set() is called the parent process will hang on started_event.wait(). This adds a timeout to started_event.wait() to avoid the parent process hanging. 